### PR TITLE
Allow client to be constructed with no arguments

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -270,6 +270,9 @@ function send_frame(stomp, frame) {
 //
 function Stomp(args) {
     events.EventEmitter.call(this);
+    if (args === undefined) {
+        args = {};
+    }
 
     this.port = args['port'] || 61613;
     this.host = args['host'] || '127.0.0.1';

--- a/test/client.js
+++ b/test/client.js
@@ -12,8 +12,16 @@ describe('Client', function() {
     var client = null;
 
     describe('#initialize', function() {
+        it('should initialize client with default arguments', function(done) {
+            client = new stomp.Stomp();
+            assert.strictEqual(client.host, '127.0.0.1');
+            assert.strictEqual(client.port, 61613);
+            assert.strictEqual(client.debug, undefined);
+            assert.strictEqual(client.ssl, false);
+            done();
+        });
 
-        it('should initialize client', function(done) {
+        it('should initialize client from object', function(done) {
             client = new stomp.Stomp(stomp_args);
             assert.strictEqual(client.host, stomp_args.host);
             assert.strictEqual(client.port, stomp_args.port);


### PR DESCRIPTION
A small change to allow creating a new Stomp client without any arguments:

```javascript
let client = new stomp.Stomp();
```

I have been setting up the callbacks when creating the client and then setting the hostname/port just before connecting.
